### PR TITLE
Fix last column/row bug

### DIFF
--- a/NBattleshipCodingContest.Logic/RandomBoardFiller.cs
+++ b/NBattleshipCodingContest.Logic/RandomBoardFiller.cs
@@ -58,8 +58,8 @@
             {
                 var direction = rand.Next(2) == 0 ? Direction.Horizontal : Direction.Vertical;
                 if (board.TryPlaceShip(new BoardIndex(
-                    rand.Next(10 - (direction == Direction.Horizontal ? shipLength : 0)), 
-                    rand.Next(10 - (direction == Direction.Vertical ? shipLength : 0))), 
+                    rand.Next(10 - (direction == Direction.Horizontal ? shipLength - 1 : 0)),
+                    rand.Next(10 - (direction == Direction.Vertical ? shipLength - 1 : 0))),
                     shipLength, direction))
                 {
                     // We found a spot


### PR DESCRIPTION
Fixes a bug that didn't allow certain ship positions.

Currently it isn't possible for a horizontal ship to occupy the last column, same for the last row on vertical ships.
Which in turn results for field J10 to never be occupied.

For example a ship with the length of 3, rand.next(10-3) -> results in a max of 6, so the ship will only span Column 6,7,8 but never the last one. 