### PR TITLE
Fix ReadOnlyBoardExtensions.TryFindShip

### DIFF
--- a/NBattleshipCodingContest.Logic.Tests/ReadOnlyBoardExtensionsTests.cs
+++ b/NBattleshipCodingContest.Logic.Tests/ReadOnlyBoardExtensionsTests.cs
@@ -91,5 +91,22 @@
             Assert.Equal(ShipFindingResult.PartialShip, board.TryFindShip(new BoardIndex(0), out BoardIndexRange ship));
             Assert.Equal(2, ship.Length);
         }
+
+        [Fact]
+        public void TryFindShip_SingleSquareHitAtTheBorder_ReturnsPartialShip()
+        {
+            //                 A1                                                                                            G10  J10
+            //                 |                                                                                               |  |
+            var boardString = "WWWWWWWWWWWWWWWWWWWWWXXXXXWWXWWWWWWWWWXWWWWWWWWWWWWWWWWWWWXWWWWWWWWWXWWXXXXWWWXWWWWWWWWWWWWWWWWWH   ";
+            var board = new BoardContent();
+            for (int i = 0; i < board.Count; i++)
+            {
+                board[new BoardIndex(i)] = BoardContentJsonConverter.CharToSquareContent(boardString[i]);
+            }
+
+            var partialShipIndex = new BoardIndex("G10");
+            var result = board.TryFindShip(partialShipIndex, out var _);
+            Assert.Equal(ShipFindingResult.PartialShip, result);
+        }
     }
 }

--- a/NBattleshipCodingContest.Logic/ReadOnlyBoardExtensions.cs
+++ b/NBattleshipCodingContest.Logic/ReadOnlyBoardExtensions.cs
@@ -91,22 +91,28 @@
             {
                 var (beginningIx, beginningComplete) = FindShipEdge(ix, direction, true);
                 var (endIx, endComplete) = FindShipEdge(ix, direction, false);
-                result = (new BoardIndexRange(beginningIx, endIx), 
+                result = (new BoardIndexRange(beginningIx, endIx),
                     beginningComplete && endComplete ? ShipFindingResult.CompleteShip : ShipFindingResult.PartialShip);
                 return result.range.Length > 1;
             }
 
-            // Go left and find first water
-            if (TryDirection(Direction.Horizontal, out var resultHorizontal))
+            // Check if the ship is placed horizontally
+            var isHorizontal = TryDirection(Direction.Horizontal, out var resultHorizontal);
+            if (isHorizontal)
             {
                 shipRange = resultHorizontal.range;
                 return resultHorizontal.complete;
             }
 
-            // Note discard operator to indicate that result is not relevant
-
-            _ = TryDirection(Direction.Vertical, out var resultVertical);
+            // Check if the ship is placed vertically
+            var isVertical = TryDirection(Direction.Vertical, out var resultVertical);
             shipRange = resultVertical.range;
+
+            // When only a single square of a ship is known, no orientation can be determined and therefore the ship is only partial.
+            if (!isHorizontal && !isVertical)
+            {
+                return ShipFindingResult.PartialShip;
+            }
             return resultVertical.complete;
         }
     }

--- a/NBattleshipCodingContest.Logic/ReadOnlyBoardExtensions.cs
+++ b/NBattleshipCodingContest.Logic/ReadOnlyBoardExtensions.cs
@@ -46,7 +46,7 @@
         {
             // Note pattern matching
 
-            if (board[ix] is not SquareContent.HitShip and not SquareContent.Ship)
+            if (board[ix] is not SquareContent.HitShip and not SquareContent.Ship and not SquareContent.SunkenShip)
             {
                 // No ship at specified index
                 shipRange = new BoardIndexRange();


### PR DESCRIPTION
When the square at the given board index is SquareContent.HitShip and the index is located at the border of the board, the method returned ShipFindingResult.CompleteShip in some circumstances.
In order to fix this, the method now returns ShipFindingResult.PartialResult when only a single square of the ship is revealed.